### PR TITLE
Refactor unnamed imports

### DIFF
--- a/flask_ext_migrate/__init__.py
+++ b/flask_ext_migrate/__init__.py
@@ -46,28 +46,32 @@ def fix_from_imports(red):
             continue
 
         if len(modules) >= 3:
-            tars_str = ''
+            name_str = ''
             if len(node.targets) == 1:
-                tar = node.targets[0]
-                if tar.target and tar.target != tar.value:
-                    tars_str = '%s as %s' % (tar.value, tar.target)
+                name = node.targets[0].target
+                module = node.targets[0].value
+
+                if (name and name != module):
+                    name_str = '%s as %s' % (module, name)
                 else:
-                    tars_str = tar.value
+                    name_str = module
             else:
-                for i in node.targets:
-                    tars_str += i.value
-                    if (i.type == 'name_as_name'
-                        and i.next
-                            and i.next.type != ('right_parenthesis')):
-                                tars_str += ', '
+                for target in node.targets:
+                    name_str += target.value
+
+                    if not target.next:
+                        continue
+
+                    if (target.type == 'name_as_name'
+                            and target.next.type != 'right_parenthesis'):
+                        name_str += ', '
 
             modules_str = '.'.join([i.value for i in modules[2:]])
 
             node.replace('from flask_%s import %s'
-                         % (modules_str, tars_str))
+                         % (modules_str, name_str))
 
         elif len(modules) == 2:
-            # simple from import
             module = node.modules()[0]
             node.replace("import flask_%s as %s"
                          % (module, module))

--- a/flask_ext_migrate/__init__.py
+++ b/flask_ext_migrate/__init__.py
@@ -33,33 +33,44 @@ def fix_from_imports(red):
     """
     Converts "from" style imports to not use "flask.ext".
 
-    Handles:
-    Case 1: from flask.ext.foo import bam --> from flask_foo import bam
-    Case 2: from flask.ext import foo --> import flask_foo as foo
+    Handles (with or without parens or linebreaks):
+    from flask.ext.foo import bam --> from flask_foo import bam
+    from flask.ext.foo.bar import bam --> from flask_foo.bar import bam
+    from flask.ext import foo --> import flask_foo as foo
     """
     from_imports = red.find_all("FromImport")
-    for x, node in enumerate(from_imports):
-        values = node.value
-        if len(values) < 2:
+    for node in from_imports:
+        modules = node.value
+
+        if modules[0].value != 'flask' and modules[1].value != 'ext':
             continue
-        if (values[0].value == 'flask') and (values[1].value == 'ext'):
-            # Case 1
-            if len(node.value) == 3:
-                package = values[2].value
-                modules = node.modules()
-                module_string = _get_modules(modules)
-                if len(modules) > 1:
-                    node.replace("from flask_%s import %s"
-                                 % (package, module_string))
+
+        if len(modules) >= 3:
+            tars_str = ''
+            if len(node.targets) == 1:
+                tar = node.targets[0]
+                if tar.target:
+                    tars_str = '%s as %s' % (tar.value, tar.target)
                 else:
-                    name = node.names()[0]
-                    node.replace("from flask_%s import %s as %s"
-                                 % (package, module_string, name))
-            # Case 2
+                    tars_str = tar.value
             else:
-                module = node.modules()[0]
-                node.replace("import flask_%s as %s"
-                             % (module, module))
+                for i in node.targets:
+                    tars_str += i.value
+                    if (i.type == 'name_as_name' 
+                        and i.next 
+                        and i.next.type != ('right_parenthesis')):
+                        tars_str += ', '
+
+            modules_str = '.'.join([i.value for i in modules[2:]])
+
+            node.replace('from flask_%s import %s' 
+                         % (modules_str, tars_str))
+
+        elif len(modules) == 2:
+            # simple from import
+            module = node.modules()[0]
+            node.replace("import flask_%s as %s"
+                         % (module, module))
     return red
 
 
@@ -83,23 +94,6 @@ def fix_standard_imports(red):
             pass
 
     return red
-
-
-def _get_modules(module):
-    """
-    Takes a list of modules and converts into a string.
-
-    The module list can include parens, this function checks each element in
-    the list, if there is a paren then it does not add a comma before the next
-    element. Otherwise a comma and space is added. This is to preserve module
-    imports which are multi-line and/or occur within parens. While also not
-    affecting imports which are not enclosed.
-    """
-    modules_string = [cur + ', ' if cur.isalnum() and next.isalnum()
-                      else cur
-                      for (cur, next) in zip(module, module[1:]+[''])]
-
-    return ''.join(modules_string)
 
 
 def fix_function_calls(red):

--- a/flask_ext_migrate/__init__.py
+++ b/flask_ext_migrate/__init__.py
@@ -56,14 +56,14 @@ def fix_from_imports(red):
             else:
                 for i in node.targets:
                     tars_str += i.value
-                    if (i.type == 'name_as_name' 
-                        and i.next 
-                        and i.next.type != ('right_parenthesis')):
-                        tars_str += ', '
+                    if (i.type == 'name_as_name'
+                        and i.next
+                            and i.next.type != ('right_parenthesis')):
+                                tars_str += ', '
 
             modules_str = '.'.join([i.value for i in modules[2:]])
 
-            node.replace('from flask_%s import %s' 
+            node.replace('from flask_%s import %s'
                          % (modules_str, tars_str))
 
         elif len(modules) == 2:

--- a/flask_ext_migrate/__init__.py
+++ b/flask_ext_migrate/__init__.py
@@ -49,7 +49,7 @@ def fix_from_imports(red):
             tars_str = ''
             if len(node.targets) == 1:
                 tar = node.targets[0]
-                if tar.target:
+                if tar.target and tar.target != tar.value:
                     tars_str = '%s as %s' % (tar.value, tar.target)
                 else:
                     tars_str = tar.value

--- a/tests/test_import_migration.py
+++ b/tests/test_import_migration.py
@@ -14,7 +14,13 @@ def test_simple_from_import():
 def test_from_to_from_import():
     red = RedBaron("from flask.ext.foo import bar")
     output = migrate.fix_tester(red)
-    assert output == "from flask_foo import bar as bar"
+    assert output == "from flask_foo import bar"
+
+
+def test_from_to_from_named_import():
+    red = RedBaron("from flask.ext.foo import bar as baz")
+    output = migrate.fix_tester(red)
+    assert output == "from flask_foo import bar as baz"
 
 
 def test_multiple_import():
@@ -54,6 +60,32 @@ def test_parens_import():
     red = RedBaron("from flask.ext.foo import (bar, foo, foobar)")
     output = migrate.fix_tester(red)
     assert output == "from flask_foo import (bar, foo, foobar)"
+
+
+def test_from_subpackages_import():
+    red = RedBaron("from flask.ext.foo.bar import foobar")
+    output = migrate.fix_tester(red)
+    assert output == "from flask_foo.bar import foobar"
+
+
+def test_from_subpackages_named_import():
+    red = RedBaron("from flask.ext.foo.bar import foobar as foobaz")
+    output = migrate.fix_tester(red)
+    assert output == "from flask_foo.bar import foobar as foobaz"
+
+
+def test_from_subpackages_parens_import():
+    red = RedBaron("from flask.ext.foo.bar import (foobar, foobarz, foobarred)")
+    output = migrate.fix_tester(red)
+    assert output == "from flask_foo.bar import (foobar, foobarz, foobarred)"
+
+
+def test_multiline_from_subpackages_import():
+    red = RedBaron("from flask.ext.foo.bar import (foobar,\
+                   foobarz,\
+                   foobarred)")
+    output = migrate.fix_tester(red)
+    assert output == "from flask_foo.bar import (foobar, foobarz, foobarred)"
 
 
 def test_function_call_migration():

--- a/tests/test_import_migration.py
+++ b/tests/test_import_migration.py
@@ -23,6 +23,18 @@ def test_from_to_from_named_import():
     assert output == "from flask_foo import bar as baz"
 
 
+def test_from_to_from_samename_import():
+    red = RedBaron("from flask.ext.foo import bar as bar")
+    output = migrate.fix_tester(red)
+    assert output == "from flask_foo import bar"
+
+
+def test_from_to_from_samename_subpackages_import():
+    red = RedBaron("from flask.ext.foo.bar import baz as baz")
+    output = migrate.fix_tester(red)
+    assert output == "from flask_foo.bar import baz"
+
+
 def test_multiple_import():
     red = RedBaron("from flask.ext.foo import bar, foobar, something")
     output = migrate.fix_tester(red)


### PR DESCRIPTION
I think this addresses most of the issues commented on in pull request #11 and I think it's a little better because there are fewer long lines.

On line 66, `'right-parenthesis'` is the RedBaron node type, like `'name_as_name'` on the line above.

I'm not really sure what you meant by your comment about the [tests](https://github.com/pallets/flask-ext-migrate/pull/11/files/4e64ccb2fcb54658cc118de23db6c82609e8154a#r73260839). Should those changes be in a separate commit?
