### PR TITLE
Remove Python 2.6/3.3 builds from CI, no flake8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ sudo: false
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "pypy"
-  - "3.3"
   - "3.4"
+  - "3.5"
 
 install:
     - pip install tox>=1.8 flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34
+envlist = py27,pypy,py34,py35
 
 [testenv]
 commands =


### PR DESCRIPTION
Flake8 doesn't support Python 2.6 any longer. Open to other suggestions on handling this.

see: http://flake8.pycqa.org/en/latest/release-notes/3.0.0.html
