### PR TITLE
Fix broken from import fixer

### DIFF
--- a/flask_ext_migrate/__init__.py
+++ b/flask_ext_migrate/__init__.py
@@ -34,7 +34,9 @@ def fix_from_imports(red):
     for node in from_imports:
         modules = node.value
 
-        if modules[0].value != 'flask' and modules[1].value != 'ext':
+        if (len(modules) < 2 or
+                modules[0].value != 'flask' or
+                modules[1].value != 'ext'):
             continue
 
         if len(modules) >= 3:

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -23,6 +23,18 @@ def test_base_flask_from_import_unchanged():
     assert output == "from flask import Flask"
 
 
+def test_base_non_flask_from_import_doesnt_raise():
+    try:
+        migrate.fix_tester("from foo import bar")
+    except Exception as e:
+        pytest.fail(e)
+
+
+def test_base_non_flask_from_import_unchanged():
+    output = migrate.fix_tester("from foo import bar")
+    assert output == "from foo import bar"
+
+
 def test_invalid_import_doesnt_raise():
     try:
         migrate.fix_tester("import adjfsjdn")


### PR DESCRIPTION
So I was right initially in https://github.com/pallets/flask-ext-migrate/pull/11#discussion_r75599406, removing the length check causes there to be an IndexError for normal base imports such as 'from foo import bar'. I added a failing test then added back the prior length checks. Also, we can short circuit the module value check if we realize the import is not from flask.
