### PR TITLE
Pin Baron/RedBaron versions to 0.6.2, fixes #27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='flask_ext_migrate',
-    version='1.0.0',
+    version='1.0.1',
     url='https://github.com/pallets/flask-ext-migrate',
     license='BSD',
     author='Keyan Pishdadian',
@@ -12,7 +12,7 @@ setup(
     description='A sourcecode manipulation tool for converting imports.',
     long_description='This tool allows for rapid migration of extension '
                      'imports away from the deprecated `.ext` format.',
-    install_requires=['RedBaron', 'click'],
+    install_requires=['redbaron==0.6.2', 'baron==0.6.2', 'click'],
     tests_require=['nose'],
     packages=['flask_ext_migrate'],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ commands =
 deps=
     pytest
     greenlet
-    redbaron
+    redbaron==0.6.2
+    baron==0.6.2
 
 [flake8]
 exclude=.tox,examples,docs


### PR DESCRIPTION
I'm still trying to narrow down exactly why the Baron `0.6.3` upgrade broke this, but the timing of the release, [this commit](https://github.com/PyCQA/redbaron/commit/7de730dc19326e12a6c50ad175435f835a30b99e), and when issue #27 was opened suggested a downgrade would resolve it.

I confirmed by downloading @louking's application and attempting to clean his import extensions. I was able to do this successfully with the Baron downgrade.